### PR TITLE
fix: Use the correct icon for the suspend button

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -135,7 +135,7 @@ const Extension = new Lang.Class({
     },
 
     _createActions: function() {
-        this._altsuspendAction = this.systemMenu._createActionButton('media-playback-pause-symbolic', _("Suspend"));
+        this._altsuspendAction = this.systemMenu._createActionButton('system-suspend-symbolic', _("Suspend"));
         this._altsuspendActionID = this._altsuspendAction.connect('clicked', Lang.bind(this, this._onSuspendClicked));
 
         this._altpowerOffAction = this.systemMenu._createActionButton('system-shutdown-symbolic', _("Power Off"));


### PR DESCRIPTION
This got switched to the pause icon. We want to use the system suspend icon.

Fixes #6